### PR TITLE
#29401657 implement users delete gif feature

### DIFF
--- a/src/controllers/GifController.js
+++ b/src/controllers/GifController.js
@@ -2,7 +2,7 @@ import {
   errorResponse, successResponse
 } from '../utils';
 import { uploadCloudinary } from '../services';
-import { createItem } from '../database/query/helper';
+import { createItem, deleteItem, getItem } from '../database/query/helper';
 
 
 /**
@@ -40,6 +40,30 @@ export default class GifController {
       return errorResponse(res, 500, 'Server error');
     } catch (error) {
       return errorResponse(res, 500, 'Internal server error');
+    }
+  }
+
+  /**
+  * @method deleteGif
+  * @description - method for users to delete an existing gif
+  * @param {object} req - request object
+  * @param {object} res - response object
+  * @return {object} request response body
+  */
+  static async deleteGif(req, res) {
+    try {
+      const { userId } = req.user;
+      const { id: gifId } = req.params;
+      const { result: gif } = await getItem('gifs', { id: gifId });
+      if (!gif) return errorResponse(res, 404, 'Gif not found');
+      if (gif.ownerId !== userId) {
+        return errorResponse(res, 403, 'Not allowed');
+      }
+      const { result: deleted } = await deleteItem('gifs', gifId);
+      if (deleted) return successResponse(res, 200, 'gif post successfully deleted');
+      return errorResponse(res, 500, 'Server error deleting article');
+    } catch (error) {
+      return errorResponse(res, 500, 'internal server error');
     }
   }
 }

--- a/src/routes/api/gif.js
+++ b/src/routes/api/gif.js
@@ -3,7 +3,7 @@ import { validate, Authenticate } from '../../middlewares';
 import { GifController } from '../../controllers';
 
 const { verifyToken } = Authenticate;
-const { createGif } = GifController;
+const { createGif, deleteGif } = GifController;
 
 const router = express.Router();
 
@@ -13,5 +13,12 @@ const router = express.Router();
   @Route: POST <domain>/api/v1/gifs
 */
 router.post('/', validate('createGif'), verifyToken, createGif);
+
+/*
+  @Description: endpoint users to delete gif
+  @Access: private only authenticated users can deleted their  gif
+  @Route: DELETE <domain>/api/v1/gifs/<:id>
+*/
+router.delete('/:id', verifyToken, deleteGif);
 
 export default router;

--- a/src/test/controllers/1-baseRoute.test.js
+++ b/src/test/controllers/1-baseRoute.test.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import pool from '../../database';
 import seedUser from '../../database/seeds/001-users';
-import seedArticle from '../../database/seeds/003-article';
 import initDb from '../../database/initDb';
 import server from '../../server';
 
@@ -17,7 +16,6 @@ describe('Base Route Test ', () => {
     await pool.clearDb();
     await initDb();
     seedUser();
-    seedArticle();
   });
   it('should return welcome to teamwork', (done) => {
     chai.request(server).get(entryRoute).end((error, response) => {

--- a/src/test/controllers/articleController.test.js
+++ b/src/test/controllers/articleController.test.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import seedArticle from '../../database/seeds/003-article';
 import server from '../../server';
 import { ArticleController } from '../../controllers';
 
@@ -16,6 +17,9 @@ const signinRoute = '/api/v1/auth/signin';
 let bearerToken;
 
 describe('Article test suite', () => {
+  before(async () => {
+    seedArticle();
+  });
   describe('creating article', () => {
     it('Should check for invalid inputs', (done) => {
       const dummyArticle = {

--- a/src/test/controllers/gifController.test.js
+++ b/src/test/controllers/gifController.test.js
@@ -2,16 +2,21 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import fs from 'fs';
 import path from 'path';
+import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import server from '../../server';
+import GifController from '../../controllers/GifController';
 
 chai.use(chaiHttp);
 chai.use(sinonChai);
 const { expect } = chai;
 
+const { deleteGif, createGif } = GifController;
+
 const gifRoute = '/api/v1/gifs';
 const signinRoute = '/api/v1/auth/signin';
 let bearerToken;
+let gifId;
 describe('Gif test suite', () => {
   describe('create gif', () => {
     it('Should check for gif file', (done) => {
@@ -41,10 +46,56 @@ describe('Gif test suite', () => {
         .attach('image', fs.readFileSync(path.resolve('./src/test/assets/gif1.gif')), 'gif1.gif')
         .end((err, gifRes) => {
           if (err) throw Error('Error making request');
+          gifId = gifRes.body.data.id;
           expect(gifRes).to.have.status(201);
           expect(gifRes.body).to.have.property('data');
           done();
         });
+    });
+  });
+  describe('delete gif', () => {
+    it('should delete gif', (done) => {
+      chai.request(server).delete(`${gifRoute}/${gifId}`).set('Authorization', bearerToken)
+        .end((err, gifRes) => {
+          if (err) throw Error('Error making request');
+          expect(gifRes).to.have.status(200);
+          done();
+        });
+    });
+    it('send not found for none existing gif', (done) => {
+      const dontExist = '012-20394-2039';
+      chai.request(server).delete(`${gifRoute}/${dontExist}`).set('Authorization', bearerToken)
+        .end((err, gifRes) => {
+          if (err) throw Error('Error making request');
+          expect(gifRes).to.have.status(404);
+          done();
+        });
+    });
+    it('Should handle error for deleteArticle', async () => {
+      const req = {};
+      const res = {
+        status: () => { },
+        json: () => { },
+      };
+      sinon.stub(res, 'status').returnsThis();
+      await deleteGif(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+    });
+    it('Controller should catch invalid request', async () => {
+      const req = {
+        user: { userId: '11111' },
+        body: {
+          title: 'some title',
+        },
+        files: { image: 'none' }
+      };
+      const res = {
+        status: () => { },
+        json: () => { },
+      };
+      sinon.stub(res, 'status').returnsThis();
+      await createGif(req, res);
+      expect(res.status).to.have.been.calledWith(500);
     });
   });
 });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -1,4 +1,4 @@
-import './controllers/baseRoute.test';
+import './controllers/1-baseRoute.test';
 import './controllers/userController.test';
 import './controllers/gifController.test';
 import './controllers/articleController.test';


### PR DESCRIPTION
#### What does this PR do?
- Allows users deleted their gif post on teamwork app

#### Description of Task to be completed?
- add delete feature to users controller
- add endpoint for users to delete gif

#### How should this be manually tested?
- clone this repository 
- run `npm install` to install all required dependencies
- ensure datebase and environment is properly setup
- start the server with `npm run start:dev`
- open postman and navigate to  POST `localhost:5000/api/v1/gifs` and post a gif
- copy the newly posted gif's id
- make anothe request with DELETE `localhost:500/api/v1/gifs<gifId/>`
- you should see a success message, that gif deleted

#### Any background context you want to provide?
- ensure database is setup
- ensure valid env variable

#### What are the relevant project board stories?
[#29401657](https://github.com/Oliver-ke/Teamwork/projects/1#card-29401657)

#### Screenshots (if appropriate)
none

#### Questions: